### PR TITLE
Fix: f90nmlのデータセットのアクセス方法を修正

### DIFF
--- a/emout/data.py
+++ b/emout/data.py
@@ -53,7 +53,7 @@ class GridData3dSeries:
         indexes = sorted(self.index2key.keys())
         for index in indexes:
             key = self.index2key[index]
-            series.append(self.group[key].value[z, y, x])
+            series.append(self.group[key][z, y, x])
         return np.array(series)
 
     def __getitem__(self, index):


### PR DESCRIPTION
dataset.value[z, y, x]からdataset[z, y, x]に修正されたため、対応